### PR TITLE
net: macsec: pass all packets in macsec dev in promiscuous mode

### DIFF
--- a/drivers/net/macsec.c
+++ b/drivers/net/macsec.c
@@ -933,7 +933,15 @@ static enum rx_handler_result handle_not_macsec(struct sk_buff *skb)
 		 * SecTAG, so we have to deduce which port to deliver to.
 		 */
 		if (macsec_get_ops(macsec, NULL) && netif_running(ndev)) {
-			if (ether_addr_equal_64bits(hdr->h_dest, ndev->dev_addr)) {
+			if (ndev->flags & IFF_PROMISC) {
+				nskb = skb_clone(skb, GFP_ATOMIC);
+				if (!nskb)
+					break;
+
+				nskb->dev = ndev;
+				netif_rx(nskb);
+			} else if (ether_addr_equal_64bits(hdr->h_dest,
+							   ndev->dev_addr)) {
 				/* HW offload enabled, divert skb */
 				skb->dev = ndev;
 				skb->pkt_type = PACKET_HOST;


### PR DESCRIPTION
In case of macsec device is added to a bridge and ofload is turned on,
received packets may be with any mac address, all of them should come to
macsec interface. Bridge turning promiscuous mode on its ports, so use
this flag to pass all packets to macsec interface.