### PR TITLE
macsec: not handle MKA packets in case of offload

### DIFF
--- a/drivers/net/macsec.c
+++ b/drivers/net/macsec.c
@@ -933,6 +933,9 @@ static enum rx_handler_result handle_not_macsec(struct sk_buff *skb)
 		 * SecTAG, so we have to deduce which port to deliver to.
 		 */
 		if (macsec_get_ops(macsec, NULL) && netif_running(ndev)) {
+			if (hdr->h_proto == htons(ETH_P_PAE))
+				continue;
+
 			if (ndev->flags & IFF_PROMISC) {
 				nskb = skb_clone(skb, GFP_ATOMIC);
 				if (!nskb)


### PR DESCRIPTION
MKA packets (ETH_P_PAE) are definitely not encrypted so
they should not be in macsec interface