### PR TITLE
Fix Compilation Error in Latest Kernel Version for Atlantic Forwarding Driver

### DIFF
--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_common.h
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_common.h
@@ -20,7 +20,7 @@
 #include <linux/netdevice.h>
 #include <linux/moduleparam.h>
 
-#define ATL_VERSION "1.1.23"
+#define ATL_VERSION "1.1.24"
 
 struct atl_nic;
 
@@ -433,5 +433,7 @@ int atl_update_thermal_flag(struct atl_hw *hw, int bit, bool val);
 int atl_verify_thermal_limits(struct atl_hw *hw, struct atl_thermal *thermal);
 int atl_do_reset(struct atl_nic *nic);
 int atl_set_media_detect(struct atl_nic *nic, bool on);
+int atl_set_downshift(struct atl_nic *nic, bool on);
+int atl2_get_fw_version(struct atl_hw *hw);
 
 #endif

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_compat.h
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_compat.h
@@ -507,4 +507,16 @@ static inline int dma_set_mask_and_coherent(struct device *dev, u64 mask)
 
 #endif /* RHEL_RELEASE_CODE < 7.2 */
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 0, 19)) || \
+	(RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(9, 1)) || \
+	(RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(8, 8))
+#define aq_netif_napi_add(dev, napi, poll, weight) netif_napi_add(dev, napi, poll)
+#else
+#define aq_netif_napi_add(dev, napi, poll, weight) netif_napi_add(dev, napi, poll, weight)
+#endif
+
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(4,3,8))
+#define strlcpy(dest, src, count) strscpy((dest), (src), (count))
+#endif
+
 #endif

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_ethtool.c
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_ethtool.c
@@ -321,12 +321,30 @@ static uint32_t atl_rss_key_size(struct net_device *ndev)
 	return ATL_RSS_KEY_SIZE;
 }
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 7, 12)
+static int atl_rss_get_rxfh(struct net_device *ndev, 
+	struct ethtool_rxfh_param *rxfh)
+#else
 static int atl_rss_get_rxfh(struct net_device *ndev, uint32_t *tbl,
 	uint8_t *key, uint8_t *htype)
+#endif
 {
 	struct atl_hw *hw = &((struct atl_nic *)netdev_priv(ndev))->hw;
 	int i;
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 7, 12)
+	if (rxfh->hfunc)
+		rxfh->hfunc = ETH_RSS_HASH_TOP;
+
+	if (rxfh->key)
+        memcpy(rxfh->key, hw->rss_key, atl_rss_key_size(ndev));
+
+	if (rxfh->indir) {
+        for (i = 0; i < atl_rss_tbl_size(ndev); i++) {
+            rxfh->indir[i] = hw->rss_tbl[i];
+        }
+    }
+#else
 	if (htype)
 		*htype = ETH_RSS_HASH_TOP;
 
@@ -336,21 +354,43 @@ static int atl_rss_get_rxfh(struct net_device *ndev, uint32_t *tbl,
 	if (tbl)
 		for (i = 0; i < atl_rss_tbl_size(ndev); i++)
 			tbl[i] = hw->rss_tbl[i];
-
+#endif
 	return 0;
 }
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 7, 12)
+static int atl_rss_set_rxfh(struct net_device *ndev, 
+	struct ethtool_rxfh_param *rxfh,
+	struct netlink_ext_ack *extack)
+#else
 static int atl_rss_set_rxfh(struct net_device *ndev, const uint32_t *tbl,
 	const uint8_t *key, const uint8_t htype)
+#endif
 {
 	struct atl_nic *nic = netdev_priv(ndev);
 	struct atl_hw *hw = &nic->hw;
 	int i;
 	uint32_t tbl_size = atl_rss_tbl_size(ndev);
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 7, 12)
+	if (rxfh->hfunc && rxfh->hfunc != ETH_RSS_HASH_TOP)
+		return -EINVAL;
+	
+	if (rxfh->indir) {
+        for (i = 0; i < tbl_size; i++) {
+            if (rxfh->indir[i] >= nic->nvecs)
+                return -EINVAL;
+            hw->rss_tbl[i] = rxfh->indir[i];
+        }
+    }
+
+	if (rxfh->key) {
+        memcpy(hw->rss_key, rxfh->key, atl_rss_key_size(ndev));
+        atl_set_rss_key(hw);
+    }
+#else
 	if (htype && htype != ETH_RSS_HASH_TOP)
 		return -EINVAL;
-
 	if (tbl) {
 		for (i = 0; i < tbl_size; i++)
 			if (tbl[i] >= nic->nvecs)
@@ -367,7 +407,7 @@ static int atl_rss_set_rxfh(struct net_device *ndev, const uint32_t *tbl,
 
 	if (tbl)
 		atl_set_rss_tbl(hw);
-
+#endif
 	return 0;
 }
 
@@ -536,8 +576,15 @@ static int atl_nway_reset(struct net_device *ndev)
 	return hw->mcp.ops->restart_aneg(hw);
 }
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 16, 20)
+static void atl_get_ringparam(struct net_device *ndev,
+	struct ethtool_ringparam *rp,
+	struct kernel_ethtool_ringparam *kernel_ring,
+	struct netlink_ext_ack *extack)
+#else
 static void atl_get_ringparam(struct net_device *ndev,
 	struct ethtool_ringparam *rp)
+#endif
 {
 	struct atl_nic *nic = netdev_priv(ndev);
 
@@ -550,8 +597,15 @@ static void atl_get_ringparam(struct net_device *ndev,
 	rp->tx_pending = nic->requested_tx_size;
 }
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 16, 20)
+static int atl_set_ringparam(struct net_device *ndev,
+	struct ethtool_ringparam *rp,
+	struct kernel_ethtool_ringparam *kernel_ring,
+	struct netlink_ext_ack *extack)
+#else
 static int atl_set_ringparam(struct net_device *ndev,
 	struct ethtool_ringparam *rp)
+#endif
 {
 	struct atl_nic *nic = netdev_priv(ndev);
 

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_fwd.c
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_fwd.c
@@ -622,9 +622,14 @@ static void __iomem *atl_msix_bar(struct atl_nic *nic)
 	if (!pdev->msix_enabled)
 		return NULL;
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(5,15,0)
+	msi = msi_first_desc(&pdev->dev, MSI_DESC_ALL);
+	return msi->pci.mask_base;
+#else
 	msi = list_first_entry(dev_to_msi_list(&pdev->dev),
-		struct msi_desc, list);
+	struct msi_desc, list);
 	return msi->mask_base;
+#endif
 }
 
 static int atl_fwd_set_msix_vec(struct atl_nic *nic, struct atl_fwd_event *evt)

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_fwd.h
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_fwd.h
@@ -442,4 +442,6 @@ int atl_get_ext_stats(struct net_device *ndev, struct atl_ext_stats *stats);
  */
 int atl_get_crash_dump(struct net_device *ndev, struct atl_crash_dump *crash_dump);
 
+int atl_fwd_reconfigure_rings(struct atl_nic *nic);
+
 #endif

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_fwdnl.c
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_fwdnl.c
@@ -152,9 +152,19 @@ void atl_fwd_get_ring_stats(struct atl_fwd_ring *ring,
 		unsigned int start;
 
 		do {
-			start = u64_stats_fetch_begin_irq(&desc->syncp);
+			#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 16))
+				start = u64_stats_fetch_begin(&desc->syncp);
+			#else
+				start = u64_stats_fetch_begin_irq(&desc->syncp);
+			#endif
 			memcpy(stats, &desc->stats, sizeof(*stats));
-		} while (u64_stats_fetch_retry_irq(&desc->syncp, start));
+		} while (
+			#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 16))
+				u64_stats_fetch_retry(&desc->syncp, start)
+			#else
+				u64_stats_fetch_retry_irq(&desc->syncp, start)
+			#endif
+		);
 	} else {
 		memset(stats, 0, sizeof(*stats));
 	}
@@ -1653,8 +1663,13 @@ static int doit_get_queue(struct sk_buff *skb, struct genl_info *info)
  *
  * Returns 0 on success, error otherwise.
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+static int atlfwd_nl_pre_doit(const struct genl_split_ops *ops, struct sk_buff *skb,
+                    struct genl_info *info)
+#else
 static int atlfwd_nl_pre_doit(const struct genl_ops *ops, struct sk_buff *skb,
-			      struct genl_info *info)
+			      	struct genl_info *info)
+#endif
 {
 	enum atlfwd_nl_attribute missing_attr = ATL_FWD_ATTR_INVALID;
 	int ring_index = S32_MIN;

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_hw.c
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_hw.c
@@ -12,6 +12,7 @@
 #include <linux/interrupt.h>
 #include <linux/pm_runtime.h>
 
+#include "atl_mdio.h"
 #include "atl_common.h"
 #include "atl_hw.h"
 #include "atl_ptp.h"

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_hw.h
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_hw.h
@@ -333,6 +333,10 @@ int atl_alloc_link_intr(struct atl_nic *nic);
 void atl_free_link_intr(struct atl_nic *nic);
 int atl_write_mcp_mem(struct atl_hw *hw, uint32_t offt, void *addr,
 	size_t size, enum mcp_area area);
+int atl_write_mcp_mem_b1(struct atl_hw *hw, uint32_t offt, void *host_addr, 
+	size_t size, enum mcp_area area);
+int atl_write_mcp_mem_b0(struct atl_hw *hw, uint32_t offt, void *host_addr, 
+	size_t size, enum mcp_area area);
 
 static inline int atl_write_fwcfg_word(struct atl_hw *hw, uint32_t offt,
 	uint32_t val)

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_hwmon.c
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_hwmon.c
@@ -23,7 +23,7 @@ static ssize_t atl_hwmon_set_flag(struct device *dev,
 	bool val;
 	int ret;
 
-	if (strtobool(buf, &val) < 0)
+	if (kstrtobool(buf, &val) < 0)
 		return -EINVAL;
 
 	ret = atl_update_thermal_flag(hw, sattr->index, val);

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_macsec.c
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_macsec.c
@@ -46,7 +46,7 @@ static int atl_apply_macsec_cfg(struct atl_hw *hw);
 static int atl_apply_secy_cfg(struct atl_hw *hw,
 			      const struct macsec_secy *secy);
 
-static void atl_ether_addr_to_mac(u32 mac[2], unsigned char *emac)
+static void atl_ether_addr_to_mac(u32 mac[2], const unsigned char *emac)
 {
 	u32 tmp[2];
 
@@ -459,8 +459,10 @@ static int atl_mdo_dev_open(struct macsec_context *ctx)
 	struct atl_nic *nic = netdev_priv(ctx->netdev);
 	int ret = 0;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	if (netif_carrier_ok(nic->ndev))
 		ret = atl_apply_secy_cfg(&nic->hw, ctx->secy);
@@ -474,8 +476,10 @@ static int atl_mdo_dev_stop(struct macsec_context *ctx)
 {
 	struct atl_nic *nic = netdev_priv(ctx->netdev);
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	atl_fwd_notify(nic, ATL_FWD_NOTIFY_MACSEC_OFF, ctx->secy->netdev);
 
@@ -661,8 +665,10 @@ static int atl_mdo_add_secy(struct macsec_context *ctx)
 	if (txsc_idx == ATL_MACSEC_MAX_SC)
 		return -ENOSPC;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	hw->macsec_cfg.sc_sa = sc_sa;
 	hw->macsec_cfg.atl_txsc[txsc_idx].hw_sc_idx =
@@ -691,8 +697,10 @@ static int atl_mdo_upd_secy(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -ENOENT;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	secy = hw->macsec_cfg.atl_txsc[txsc_idx].sw_secy;
 
@@ -764,8 +772,10 @@ static int atl_mdo_del_secy(struct macsec_context *ctx)
 {
 	struct atl_nic *nic = netdev_priv(ctx->netdev);
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	return atl_clear_secy(nic, ctx->secy, ATL_CLEAR_ALL);
 }
@@ -828,8 +838,10 @@ static int atl_mdo_add_txsa(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -EINVAL;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	atl_txsc = &hw->macsec_cfg.atl_txsc[txsc_idx];
 	set_bit(ctx->sa.assoc_num, &atl_txsc->tx_sa_idx_busy);
@@ -857,8 +869,10 @@ static int atl_mdo_upd_txsa(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -EINVAL;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	atl_txsc = &hw->macsec_cfg.atl_txsc[txsc_idx];
 	if (netif_carrier_ok(nic->ndev) && netif_running(secy->netdev))
@@ -906,8 +920,10 @@ static int atl_mdo_del_txsa(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -EINVAL;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	return atl_clear_txsa(nic, &nic->hw.macsec_cfg.atl_txsc[txsc_idx],
 			      ctx->sa.assoc_num, ATL_CLEAR_ALL);
@@ -1023,8 +1039,10 @@ static int atl_mdo_add_rxsc(struct macsec_context *ctx)
 	if (rxsc_idx >= rxsc_idx_max)
 		return -ENOSPC;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	cfg->atl_rxsc[rxsc_idx].hw_sc_idx =
 		atl_to_hw_sc_idx(rxsc_idx, cfg->sc_sa);
@@ -1054,8 +1072,10 @@ static int atl_mdo_upd_rxsc(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -ENOENT;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	if (netif_carrier_ok(nic->ndev) && netif_running(ctx->secy->netdev))
 		return atl_set_rxsc(&nic->hw, rxsc_idx);
@@ -1128,8 +1148,10 @@ static int atl_mdo_del_rxsc(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -ENOENT;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	if (netif_carrier_ok(nic->ndev))
 		clear_type = ATL_CLEAR_ALL;
@@ -1209,8 +1231,10 @@ static int atl_mdo_add_rxsa(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -EINVAL;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	set_bit(ctx->sa.assoc_num,
 		&hw->macsec_cfg.atl_rxsc[rxsc_idx].rx_sa_idx_busy);
@@ -1237,8 +1261,10 @@ static int atl_mdo_upd_rxsa(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -EINVAL;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	if (netif_carrier_ok(nic->ndev) && netif_running(secy->netdev))
 		return atl_update_rxsa(
@@ -1287,8 +1313,10 @@ static int atl_mdo_del_rxsa(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -EINVAL;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	return atl_clear_rxsa(nic, &nic->hw.macsec_cfg.atl_rxsc[rxsc_idx],
 			      ctx->sa.assoc_num, ATL_CLEAR_ALL);
@@ -1300,8 +1328,10 @@ static int atl_mdo_get_dev_stats(struct macsec_context *ctx)
 	struct atl_hw *hw = &nic->hw;
 	struct atl_macsec_common_stats *stats = &hw->macsec_cfg.stats;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	atl_get_macsec_common_stats(hw, stats);
 
@@ -1329,8 +1359,10 @@ static int atl_mdo_get_tx_sc_stats(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -ENOENT;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	atl_txsc = &hw->macsec_cfg.atl_txsc[txsc_idx];
 	stats = &atl_txsc->stats;
@@ -1361,8 +1393,10 @@ static int atl_mdo_get_tx_sa_stats(struct macsec_context *ctx)
 	if (txsc_idx < 0)
 		return -EINVAL;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	atl_txsc = &hw->macsec_cfg.atl_txsc[txsc_idx];
 	sa_idx = atl_txsc->hw_sc_idx | ctx->sa.assoc_num;
@@ -1401,8 +1435,10 @@ static int atl_mdo_get_rx_sc_stats(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -ENOENT;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	atl_rxsc = &hw->macsec_cfg.atl_rxsc[rxsc_idx];
 	for (i = 0; i < MACSEC_NUM_AN; i++) {
@@ -1449,8 +1485,10 @@ static int atl_mdo_get_rx_sa_stats(struct macsec_context *ctx)
 	if (rxsc_idx < 0)
 		return -EINVAL;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 6))
 	if (ctx->prepare)
 		return 0;
+#endif
 
 	atl_rxsc = &hw->macsec_cfg.atl_rxsc[rxsc_idx];
 	stats = &atl_rxsc->rx_sa_stats[ctx->sa.assoc_num];

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_main.c
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_main.c
@@ -282,7 +282,7 @@ static int atl_set_mac_address(struct net_device *ndev, void *priv)
 		return -EADDRNOTAVAIL;
 
 	ether_addr_copy(hw->mac_addr, addr->sa_data);
-	ether_addr_copy(ndev->dev_addr, addr->sa_data);
+	ether_addr_copy( (u8 *) ndev->dev_addr, addr->sa_data);
 
 	if (netif_running(ndev) && pm_runtime_active(&nic->hw.pdev->dev))
 		atl_set_uc_flt(hw, nic->rxf_mac.base_index, hw->mac_addr);
@@ -623,7 +623,7 @@ static int atl_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 		/* goto err_hwinit; */
 	}
 
-	ether_addr_copy(ndev->dev_addr, hw->mac_addr);
+	ether_addr_copy( (u8 *) ndev->dev_addr, hw->mac_addr);
 	atl_dev_dbg("got MAC address: %pM\n", hw->mac_addr);
 
 	ret = atl_ptp_init(nic);

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_ptp.c
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_ptp.c
@@ -284,6 +284,7 @@ static int atl_ptp_adjfine(struct ptp_clock_info *ptp_info, long scaled_ppm)
 }
 #endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
 /* atl_ptp_adjfreq
  * @ptp_info: the ptp clock structure
  * @ppb: parts per billion adjustment from base
@@ -300,6 +301,7 @@ static int atl_ptp_adjfreq(struct ptp_clock_info *ptp_info, s32 ppb)
 
 	return 0;
 }
+#endif
 
 /* atl_ptp_adjtime
  * @ptp_info: the ptp clock structure
@@ -622,7 +624,9 @@ static struct ptp_clock_info atl_ptp_clock = {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
 	.adjfine	= atl_ptp_adjfine,
 #endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
 	.adjfreq	= atl_ptp_adjfreq,
+#endif
 	.adjtime	= atl_ptp_adjtime,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
 	.gettime64	= atl_ptp_gettime,
@@ -1153,7 +1157,7 @@ int atl_ptp_ring_start(struct atl_nic *nic)
 			goto stop;
 	}
 
-	netif_napi_add(nic->ndev, ptp->napi, atl_ptp_poll, 64);
+	aq_netif_napi_add(nic->ndev, ptp->napi, atl_ptp_poll, 64);
 	napi_enable(ptp->napi);
 
 	return 0;

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_ring.c
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_ring.c
@@ -1444,7 +1444,7 @@ void atl_init_qvec(struct atl_nic *nic, struct atl_queue_vec *qvec, int idx)
 	u64_stats_init(&qvec->tx.syncp);
 
 	if (likely(qvec->type == ATL_QUEUE_REGULAR))
-		netif_napi_add(nic->ndev, &qvec->napi, atl_poll, 64);
+		aq_netif_napi_add(nic->ndev, &qvec->napi, atl_poll, 64);
 }
 
 int atl_setup_datapath(struct atl_nic *nic)
@@ -2141,9 +2141,19 @@ void atl_get_ring_stats(struct atl_desc_ring *ring,
 	unsigned int start;
 
 	do {
-		start = u64_stats_fetch_begin_irq(&ring->syncp);
+		#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 16))
+			start = u64_stats_fetch_begin(&ring->syncp);
+		#else
+			start = u64_stats_fetch_begin_irq(&ring->syncp);
+		#endif
 		memcpy(stats, &ring->stats, sizeof(*stats));
-	} while (u64_stats_fetch_retry_irq(&ring->syncp, start));
+	} while (
+		#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 16))
+			u64_stats_fetch_retry(&ring->syncp, start)
+		#else
+			u64_stats_fetch_retry_irq(&ring->syncp, start)
+		#endif
+	);
 }
 
 #define atl_add_stats(_dst, _src)				\

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/atl_ring.h
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/atl_ring.h
@@ -199,6 +199,11 @@ int atl_clean_rx(struct atl_desc_ring *ring, int budget,
 int atl_clean_hwts_rx(struct atl_desc_ring *ring, int budget);
 void atl_clear_rx_bufs(struct atl_desc_ring *ring);
 
+bool atl_rx_checksum(struct sk_buff *skb, struct atl_rx_desc_wb *desc,
+		 struct atl_desc_ring *ring);
+void atl_rx_hash(struct sk_buff *skb, struct atl_rx_desc_wb *desc,
+		 struct net_device *ndev);
+
 #ifdef ATL_RINGS_IN_UC_MEM
 
 #define DECLARE_SCRATCH_DESC(_name) union atl_desc _name

--- a/drivers/net/ethernet/aquantia/atlantic-fwd/release_notes.txt
+++ b/drivers/net/ethernet/aquantia/atlantic-fwd/release_notes.txt
@@ -1,3 +1,8 @@
+Version 1.1.24
+Date 03/04/2025
+==============
+- Compilation issues have been fixed for the latest kernel versions.
+
 Version 1.1.23
 Date 02/11/2021
 ==============


### PR DESCRIPTION
Compilation issues have been fixed for the latest kernel versions.